### PR TITLE
mount ssl folder for write

### DIFF
--- a/heimdall/config.json
+++ b/heimdall/config.json
@@ -26,7 +26,7 @@
   "map": [
     "config:rw",
     "share:rw",
-    "ssl"
+    "ssl:rw"
   ],
   "webui": "http://[HOST]:[PORT:82]",
   "boot": "auto",


### PR DESCRIPTION
The container tries to write a certificate to ssl folder at first boot but it is mounted as read-only