### PR TITLE
Add DLNA port 1900 to Jellyfin addon

### DIFF
--- a/jellyfin/config.json
+++ b/jellyfin/config.json
@@ -16,10 +16,12 @@
     "armhf"
   ],
   "ports": {
-    "8096/tcp": 8096
+    "8096/tcp": 8096,
+    "1900/tcp": 1900,
   },
   "ports_description": {
-    "8096/tcp": "web interface"
+    "8096/tcp": "web interface",
+    "1900/tcp": "dlna",
   },
   "map": [
     "config:rw",


### PR DESCRIPTION
I have noticed that DLNA doesn't work with Jellyfin and it seems to be because this addon doesn't export port 1900 which is used by DLNA. This should fix the issue.