### PR TITLE
fix heimdall s6-overlay init

### DIFF
--- a/heimdall/CHANGELOG.md
+++ b/heimdall/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.0
+## 0.3.1
 
  - Update heimdall to 2.5.5 (linuxserver/heimdall:v2.5.5-ls198)
 

--- a/heimdall/config.json
+++ b/heimdall/config.json
@@ -1,8 +1,9 @@
 {
   "name": "heimdall",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "slug": "heimdall",
   "legacy": false,
+  "init": false,
   "maintenance": {
     "github_release": "https://github.com/linuxserver/docker-heimdall",
     "version_regex": "(\\d+\\.\\d+\\.\\d+)-(ls\\d+)"


### PR DESCRIPTION
see https://developers.home-assistant.io/blog/2022/05/12/s6-overlay-base-images/?fbclid=IwAR0yg_p3aayehr4YooJDSLMadlrTC5anlbz3xdA2BwdxdpKRAPZ9hJL4w4M

fixes #118 